### PR TITLE
fix list window panes, #7

### DIFF
--- a/window.go
+++ b/window.go
@@ -28,7 +28,7 @@ func NewWindow(id int, name string, sessionId int, sessionName string, startDire
 
 // Returns a list with all panes for this window.
 func (w *Window) ListPanes() ([]Pane, error) {
-	return ListPanes([]string{"-s", "-t", w.Name})
+	return ListPanes([]string{"-t", w.Name})
 }
 
 // Adds the pane to the window configuration. This will change only in-library


### PR DESCRIPTION
* [list-panes](https://man.openbsd.org/tmux#list-panes) [-as] [-F format] [-f filter] [-t target]
> If -s is given, target is a session (or the current session). If neither is given, target is a window (or the current window)
* When I omit the `-s` , I only get the window panes in my tests.

Note on the tests:

- When I run the tests locally, they only run "TestPaneGetCurrentPath"

```
➜  go-tmux git:(fix-windows-list-panes) ✗ go test -v
=== RUN   TestPaneGetCurrentPath
ok      github.com/jubnzv/go-tmux       0.111s
```

* Maybe I am doing it wrong, dunno.
